### PR TITLE
Add user permissions management UI

### DIFF
--- a/src/apiRoutes.ts
+++ b/src/apiRoutes.ts
@@ -19,6 +19,9 @@ const apiRoutes = {
     byOrganization: (organizationId: string) =>
       `${API_BASE_URL}/applications/organization/${organizationId}`,
   },
+  userPermissions: {
+    base: `${API_BASE_URL}/user-permissions`,
+  },
 };
 
 export default apiRoutes;

--- a/src/app/admin/permissions/PermissionForm.tsx
+++ b/src/app/admin/permissions/PermissionForm.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+
+const PermissionForm = ({ formData, setFormData, users, organizations, applications, onSubmit, onCancel }: any) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, type, checked, value } = e.target;
+    setFormData({
+      ...formData,
+      [name]: type === 'checkbox' ? checked : value,
+    });
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="username" className="block text-sm font-medium text-gray-300 mb-1">
+          User
+        </label>
+        <select
+          id="username"
+          name="username"
+          value={formData.username || ''}
+          onChange={handleChange}
+          className="w-full bg-gray-700 text-white border border-gray-600 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+        >
+          <option value="">Select user</option>
+          {users.map((u: any) => (
+            <option key={u.username} value={u.username}>
+              {u.username}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label htmlFor="organizationId" className="block text-sm font-medium text-gray-300 mb-1">
+          Organization
+        </label>
+        <select
+          id="organizationId"
+          name="organizationId"
+          value={formData.organizationId || ''}
+          onChange={handleChange}
+          className="w-full bg-gray-700 text-white border border-gray-600 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+        >
+          <option value="">Select organization</option>
+          {organizations.map((o: any) => (
+            <option key={o.id} value={o.id}>
+              {o.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label htmlFor="applicationId" className="block text-sm font-medium text-gray-300 mb-1">
+          Application
+        </label>
+        <select
+          id="applicationId"
+          name="applicationId"
+          value={formData.applicationId || ''}
+          onChange={handleChange}
+          className="w-full bg-gray-700 text-white border border-gray-600 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+        >
+          <option value="">Select application</option>
+          {applications.map((a: any) => (
+            <option key={a.id} value={a.id}>
+              {a.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <label className="flex items-center">
+          <input type="checkbox" name="canRead" checked={formData.canRead || false} onChange={handleChange} className="mr-2" />
+          Read
+        </label>
+        <label className="flex items-center">
+          <input type="checkbox" name="canCreate" checked={formData.canCreate || false} onChange={handleChange} className="mr-2" />
+          Create
+        </label>
+        <label className="flex items-center">
+          <input type="checkbox" name="canUpdate" checked={formData.canUpdate || false} onChange={handleChange} className="mr-2" />
+          Update
+        </label>
+        <label className="flex items-center">
+          <input type="checkbox" name="canDelete" checked={formData.canDelete || false} onChange={handleChange} className="mr-2" />
+          Delete
+        </label>
+      </div>
+      <div className="flex justify-end space-x-4">
+        <button type="button" onClick={onCancel} className="bg-gray-600 text-white px-4 py-2 rounded-lg hover:bg-gray-500">
+          Cancel
+        </button>
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-500">
+          Save
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default PermissionForm;

--- a/src/app/admin/permissions/PermissionTable.tsx
+++ b/src/app/admin/permissions/PermissionTable.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+const PermissionTable = ({ permissions, onEdit, onDelete, organizations, applications }: any) => {
+  const getOrgName = (id: number) => {
+    const org = organizations.find((o: any) => o.id === id);
+    return org ? org.name : id;
+  };
+
+  const getAppName = (id: number) => {
+    const app = applications.find((a: any) => a.id === id);
+    return app ? app.name : id;
+  };
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full bg-gray-800 text-gray-300 rounded-lg">
+        <thead>
+          <tr className="bg-gray-700">
+            <th className="px-4 py-2 text-left">User</th>
+            <th className="px-4 py-2 text-left">Organization</th>
+            <th className="px-4 py-2 text-left">Application</th>
+            <th className="px-4 py-2 text-center">Read</th>
+            <th className="px-4 py-2 text-center">Create</th>
+            <th className="px-4 py-2 text-center">Update</th>
+            <th className="px-4 py-2 text-center">Delete</th>
+            <th className="px-4 py-2 text-center">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {permissions.map((perm: any) => (
+            <tr key={perm.id} className="border-t border-gray-700 hover:bg-gray-700">
+              <td className="px-4 py-2">{perm.username}</td>
+              <td className="px-4 py-2">{getOrgName(perm.organizationId)}</td>
+              <td className="px-4 py-2">{getAppName(perm.applicationId)}</td>
+              <td className="px-4 py-2 text-center">{perm.canRead ? '✓' : '-'}</td>
+              <td className="px-4 py-2 text-center">{perm.canCreate ? '✓' : '-'}</td>
+              <td className="px-4 py-2 text-center">{perm.canUpdate ? '✓' : '-'}</td>
+              <td className="px-4 py-2 text-center">{perm.canDelete ? '✓' : '-'}</td>
+              <td className="px-4 py-2 text-center">
+                <button
+                  onClick={() => onEdit(perm)}
+                  className="inline-flex items-center px-3 py-1 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-yellow-600 hover:bg-yellow-700 mr-2"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => onDelete(perm.id)}
+                  className="inline-flex items-center px-3 py-1 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-red-600 hover:bg-red-700"
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default PermissionTable;

--- a/src/app/admin/permissions/page.tsx
+++ b/src/app/admin/permissions/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import axiosInstance from '@/axiosConfig';
+import apiRoutes from '@/apiRoutes';
+import PermissionForm from './PermissionForm';
+import PermissionTable from './PermissionTable';
+
+const PermissionsPage = () => {
+  const [permissions, setPermissions] = useState([]);
+  const [users, setUsers] = useState([]);
+  const [organizations, setOrganizations] = useState([]);
+  const [applications, setApplications] = useState([]);
+  const [formData, setFormData] = useState({
+    username: '',
+    organizationId: '',
+    applicationId: '',
+    canRead: false,
+    canCreate: false,
+    canUpdate: false,
+    canDelete: false,
+  });
+  const [editingPerm, setEditingPerm] = useState<any>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const fetchPermissions = async () => {
+    try {
+      const res = await axiosInstance.get(apiRoutes.userPermissions.base);
+      setPermissions(res.data);
+    } catch (err) {
+      console.error('Error fetching permissions:', err);
+    }
+  };
+
+  const fetchUsers = async () => {
+    try {
+      const res = await axiosInstance.get(apiRoutes.users.base);
+      setUsers(res.data);
+    } catch (err) {
+      console.error('Error fetching users:', err);
+    }
+  };
+
+  const fetchOrganizations = async () => {
+    try {
+      const res = await axiosInstance.get(apiRoutes.organizations.base);
+      setOrganizations(res.data);
+    } catch (err) {
+      console.error('Error fetching organizations:', err);
+    }
+  };
+
+  const fetchApplications = async () => {
+    try {
+      const res = await axiosInstance.get(apiRoutes.applications.base);
+      setApplications(res.data);
+    } catch (err) {
+      console.error('Error fetching applications:', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchPermissions();
+    fetchUsers();
+    fetchOrganizations();
+    fetchApplications();
+  }, []);
+
+  const handleCreate = () => {
+    setFormData({
+      username: '',
+      organizationId: '',
+      applicationId: '',
+      canRead: false,
+      canCreate: false,
+      canUpdate: false,
+      canDelete: false,
+    });
+    setEditingPerm(null);
+    setShowForm(true);
+  };
+
+  const handleEdit = (perm: any) => {
+    setFormData(perm);
+    setEditingPerm(perm);
+    setShowForm(true);
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await axiosInstance.delete(`${apiRoutes.userPermissions.base}/${id}`);
+      fetchPermissions();
+    } catch (err) {
+      console.error('Error deleting permission:', err);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      if (editingPerm) {
+        await axiosInstance.put(`${apiRoutes.userPermissions.base}/${editingPerm.id}`, formData);
+      } else {
+        await axiosInstance.post(apiRoutes.userPermissions.base, formData);
+      }
+      setShowForm(false);
+      setEditingPerm(null);
+      fetchPermissions();
+    } catch (err) {
+      console.error('Error saving permission:', err);
+    }
+  };
+
+  return (
+    <div className="bg-gray-900 text-gray-200 p-6 rounded-lg shadow-md">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">Permissions</h1>
+        {!showForm && (
+          <button onClick={handleCreate} className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700">
+            Create Permission
+          </button>
+        )}
+      </div>
+      {showForm ? (
+        <div className="bg-gray-800 p-6 rounded-lg shadow-lg">
+          <PermissionForm
+            formData={formData}
+            setFormData={setFormData}
+            users={users}
+            organizations={organizations}
+            applications={applications}
+            onSubmit={handleSubmit}
+            onCancel={() => setShowForm(false)}
+          />
+        </div>
+      ) : (
+        <PermissionTable
+          permissions={permissions}
+          organizations={organizations}
+          applications={applications}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+        />
+      )}
+    </div>
+  );
+};
+
+export default PermissionsPage;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -330,6 +330,22 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                         Roles Management
                       </Link>
                     </li>
+                    <li>
+                      <Link
+                        href="/admin/permissions"
+                        className="flex items-center p-2 text-gray-300 hover:text-white hover:bg-gray-600 rounded-lg"
+                      >
+                        <svg
+                          className="w-5 h-5 mr-2 text-gray-400"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-3-3v6m9-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        Permissions
+                      </Link>
+                    </li>
                   </>
                 )}
               </ul>


### PR DESCRIPTION
## Summary
- add API route for user permissions
- add permissions page with form and table
- include permissions link in settings menu

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d5a647608329b97fbaa92f0143a3