### PR TITLE
Fix permission form submission

### DIFF
--- a/src/app/admin/permissions/page.tsx
+++ b/src/app/admin/permissions/page.tsx
@@ -96,6 +96,7 @@ const PermissionsPage = () => {
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
     try {
       if (editingPerm) {
         await axiosInstance.put(`${apiRoutes.userPermissions.base}/${editingPerm.id}`, formData);


### PR DESCRIPTION
## Summary
- prevent default form submission in Permissions page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466ba566e08329b52568c81cf0339d